### PR TITLE
Change hydrogen on hydrogen mapping default to True

### DIFF
--- a/src/kartograf/atom_mapper.py
+++ b/src/kartograf/atom_mapper.py
@@ -72,7 +72,7 @@ class KartografAtomMapper(AtomMapper):
             *,
             atom_max_distance: float = 0.95,
             atom_map_hydrogens: bool = True,
-            map_hydrogens_on_hydrogens_only: bool = False,
+            map_hydrogens_on_hydrogens_only: bool = True,
             map_exact_ring_matches_only: bool = True,
             allow_partial_fused_rings: bool = True,
             additional_mapping_filter_functions: Optional[Iterable[Callable[[
@@ -88,8 +88,10 @@ class KartografAtomMapper(AtomMapper):
         atom_max_distance : float, optional
             geometric criteria for two atoms, how far their distance
             can be maximal (in Angstrom). Default 0.95
+        atom_map_hydrogens : bool, optional
+            If hydrogens should be included in the atom mapping. Default True
         map_hydrogens_on_hydrogens_only : bool, optional
-            map hydrogens only on hydrogens. Default False
+            map hydrogens only on hydrogens. Default True
         map_exact_ring_matches_only : bool, optional
             if true, only rings with matching ringsize and same bond-orders
             will be mapped. Additionally no ring-breaking is permitted. default

--- a/src/kartograf/tests/conftest.py
+++ b/src/kartograf/tests/conftest.py
@@ -43,7 +43,7 @@ def stereco_chem_molecules():
 @pytest.fixture(scope="session")
 def stereo_chem_mapping():
     mols = stereo_chem_mols()
-    expected_mapping = {2: 7, 4: 4, 5: 5, 6: 6, 7: 2, 0: 0, 1: 1, 3: 3}
+    expected_mapping = {4: 4, 5: 5, 6: 6, 0: 0, 1: 1, 3: 3}
 
     return LigandAtomMapping(mols[0], mols[1], expected_mapping)
 


### PR DESCRIPTION
Following the review of the default filters in #59, this PR changes the default value for `map_hydrogens_on_hydrogens_only` to `True` this should have no change on the performance when using the hybrid topology protocol from OpenFE as these mappings were removed silently as they involve bond constraints. 