### PR TITLE
remove outdated pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,6 @@ kartograf_mapping
 ### Latest release
 Kartograf can be installed via the package following package managers:
 
-#### `pip` (PyPI)
-
-```shell
-pip install kartograf
-```
-
 #### `conda` (conda-forge)
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Kartograf: A Geometry-Based Atom Mapper
 [![coverage](https://codecov.io/gh/OpenFreeEnergy/kartograf/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenFreeEnergy/kartograf)
 [![Documentation Status](https://readthedocs.org/projects/kartograf/badge/?version=latest)](https://kartograf.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10566716.svg)](https://doi.org/10.5281/zenodo.10566716)
-
-[![Pip Install](https://img.shields.io/badge/pip%20install-kartograf-d9c4b1)](https://pypi.org/project/kartograf/)
 [![Conda Install](https://img.shields.io/badge/Conda%20install---c%20conda--forge%20kartograf-009384)](https://anaconda.org/conda-forge/kartograf)
 
 Kartograf is a package for atom mappings focussing on 3D geometries.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,8 +12,6 @@ Kartograf is packaged with OpenFE and can be directly imported from there with:
 Alternatively, you can install Kartograf also as a standalone package via pip
 or conda:
 
-``pip install kartograf``
-
 ``conda install -c conda-forge kartograf``
 
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/kartograf/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.