### PR TITLE
Package for PyPI

### DIFF
--- a/devtools/pypi-pkg/README.md
+++ b/devtools/pypi-pkg/README.md
@@ -1,0 +1,3 @@
+Please use conda-forge to install kartograf:
+
+`conda install -c conda-forge kartograf`

--- a/devtools/pypi-pkg/kartograf/__init__.py
+++ b/devtools/pypi-pkg/kartograf/__init__.py
@@ -1,0 +1,3 @@
+print("This isn't the package you are looking for")
+print("Please install kartograf from conda-forge")
+print("conda install -c conda-forge kartograf")

--- a/devtools/pypi-pkg/pyproject.toml
+++ b/devtools/pypi-pkg/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kartograf"
+version = "1.0.2"
+description = "Please use conda-forge to install kartograf"
+authors = [{ name = "Mike Henry", email = "mike.henry@omsf.io" }]
+readme = "README.md"
+requires-python = ">=3.7"
+license = { text = "MIT" }
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["."]


### PR DESCRIPTION
I want to replace the pypi package we have with this one that tells users to install our conda-forge package.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/kartograf/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.