### PR TITLE
Use dict|list comprehension for speedups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,11 @@ lint.select = [
   "FURB", # A tool for refurbishing and modernizing Python codebases https://github.com/dosisod/refurb
   "I",    # isort
   # "C901",  # mccabe complexity  TODO: add this back in
-  "S",   # security related lint https://pypi.org/project/flake8-bandit/
-  "UP",  # pyupgrade
-  "W",   # pycodestyle warnings
-  "YTT", # detect issues using sys to check python version https://pypi.org/project/flake8-2020/
+  "PERF", # performance linting https://github.com/tonybaloney/perflint
+  "S",    # security related lint https://pypi.org/project/flake8-bandit/
+  "UP",   # pyupgrade
+  "W",    # pycodestyle warnings
+  "YTT",  # detect issues using sys to check python version https://pypi.org/project/flake8-2020/
 ]
 
 lint.ignore = [

--- a/src/kartograf/atom_mapper.py
+++ b/src/kartograf/atom_mapper.py
@@ -425,11 +425,7 @@ class KartografAtomMapper(AtomMapper):
             filtered mapping
 
         """
-        filtered_mapping = {}
-        for atom_a, atom_b in mapping.items():
-            if atom_a in set_a and atom_b in set_b:
-                filtered_mapping[atom_a] = atom_b
-        return filtered_mapping
+        return {atom_a: atom_b for atom_a, atom_b in mapping.items() if atom_a in set_a and atom_b in set_b}
 
     """
         Utils

--- a/src/kartograf/tests/test_atom_mapper.py
+++ b/src/kartograf/tests/test_atom_mapper.py
@@ -276,12 +276,10 @@ def test_split_multimeric_component() -> None:
     input_pdb = str(files("kartograf.tests.data") / "2wtk_trimer_with_extra_mols.pdb")
     pdb = PDBFile(input_pdb)
     omm_topology = pdb.topology
-    # Create the data structure we want to compare to: list[Dict]
-    omm_data = []
     # It happens that number of components is the number of chains for this pdb, but doesn't have to
     expected_n_comps = len(list(omm_topology.chains()))
-    for chain in omm_topology.chains():
-        omm_data.append({"residues": len(list(chain.residues())), "atoms": len(list(chain.atoms()))})
+
+    omm_data = [{"residues": len(list(chain.residues())), "atoms": len(list(chain.atoms()))} for chain in omm_topology.chains()]
 
     protein_comp = ProteinComponent.from_pdb_file(input_pdb)
     chain_comps = KartografAtomMapper._split_component_molecules(protein_comp)

--- a/src/kartograf/tests/test_atom_mapper.py
+++ b/src/kartograf/tests/test_atom_mapper.py
@@ -279,7 +279,9 @@ def test_split_multimeric_component() -> None:
     # It happens that number of components is the number of chains for this pdb, but doesn't have to
     expected_n_comps = len(list(omm_topology.chains()))
 
-    omm_data = [{"residues": len(list(chain.residues())), "atoms": len(list(chain.atoms()))} for chain in omm_topology.chains()]
+    omm_data = [
+        {"residues": len(list(chain.residues())), "atoms": len(list(chain.atoms()))} for chain in omm_topology.chains()
+    ]
 
     protein_comp = ProteinComponent.from_pdb_file(input_pdb)
     chain_comps = KartografAtomMapper._split_component_molecules(protein_comp)


### PR DESCRIPTION
fixes #109 
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/kartograf/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
